### PR TITLE
Add dry-run and output path options for changelog generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ To automate and standardize the DevOps workflow from documentation through deplo
    python changelog.py
    ```
 
+   Preview the generated changelog without writing to disk:
+
+   ```bash
+   python changelog.py --dry-run
+   ```
+
+   Write the changelog to a custom destination:
+
+   ```bash
+   python changelog.py --output ./CHANGELOG.preview.md
+   ```
+
 ## 📄 Output
 
 - `CHANGELOG.md` – A changelog file generated from pull requests
@@ -67,6 +79,7 @@ To automate and standardize the DevOps workflow from documentation through deplo
 
 - This script is intended for use in Python-based CI/CD environments.
 - Can be integrated into GitHub Actions, GitLab CI, or other pipelines.
+- `--dry-run` prints the generated changelog to stdout, and `--output` overrides the destination file path.
 - OpenAI is used to generate natural-language summaries of pull request activity and development changes.
 
 ## 📃 License

--- a/changelog.py
+++ b/changelog.py
@@ -352,10 +352,14 @@ if any(all_repo_items.values()):
     changelog_content += "\n\n"
     changelog_content += "Special thanks to the development team, [@BytesCrafter](https://github.com/BytesCrafter), [@caezariidecastro](https://github.com/caezariidecastro), [@BC-Tristan](https://github.com/BC-Tristan), [@BC-Patrick](https://github.com/BC-Patrick)! 💯🥳\n"
 
-    # Write to CHANGELOG file with UTF-8 encoding
-    with open(log_path, "w", encoding="utf-8") as file:
-        file.write(changelog_content)
-    
-    print(f"{assistant}: Changelog written to {log_path}")
+    if args.dry_run:
+        print(f"{assistant}: Dry-run enabled; generated changelog preview follows:\n")
+        print(changelog_content)
+    else:
+        # Write to CHANGELOG file with UTF-8 encoding
+        with open(log_path, "w", encoding="utf-8") as file:
+            file.write(changelog_content)
+
+        print(f"{assistant}: Changelog written to {log_path}")
 else:
     print(f"{assistant}: No {github_target} found or failed to fetch them.")

--- a/changelog.py
+++ b/changelog.py
@@ -8,6 +8,7 @@
 # ===============================================================================
 
 import os
+import argparse
 from datetime import datetime
 from dotenv import load_dotenv
 load_dotenv()
@@ -20,8 +21,25 @@ from openai import OpenAI
 assistant = os.getenv("ASSISTANT_NAME", "PEASANT")
 print(f"{assistant}: CHANGELOG generation is initializing...")
 
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate a changelog from GitHub pull requests or issues.")
+    parser.add_argument(
+        "--output",
+        help="Override the output path for the generated changelog file.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the generated changelog without writing it to disk.",
+    )
+    return parser.parse_args()
+
+
+args = parse_args()
+
 project_name = os.getenv("RELEASE_NAME")
-project_path = os.getenv("PROJECT_PATH")
+project_path = os.getenv("PROJECT_PATH") or os.getcwd()
 
 compare_base = os.getenv("GITHUB_COMPARED_BASE", "release")
 compare_head = os.getenv("GITHUB_COMPARED_HEAD", "develop")
@@ -281,6 +299,8 @@ print(f"{assistant}: Completed processing items from server.")
 
 # Calculate the path two directories back
 log_path = os.path.join(project_path, "CHANGELOG.md")
+if args.output:
+    log_path = args.output
 
 # Proceed with writing the changelog if pull requests were fetched
 if any(all_repo_items.values()):


### PR DESCRIPTION
# Add dry-run and output path options for changelog generation
## **SUMMARY**
Adds a lightweight CLI to `changelog.py` so operators can preview generated content or direct output to a custom path without changing environment variables.

## **LINKED ISSUES**
Closes #10

## **PR TYPE & SCOPE**
Feature / changelog ergonomics

## **FEATURES / CHANGES IMPLEMENTED**
- Added `--output` to override the generated changelog destination.
- Added `--dry-run` to print the generated changelog instead of writing it to disk.
- Made the default project path resolution safer when `PROJECT_PATH` is not set.
- Documented both flags in the README usage section.

## **FILES ADDED**
None.

## **FILES MODIFIED**
- `changelog.py`
- `README.md`

## **TECH STACK DETAILS**
- Python 3.8+
- Standard library `argparse`
- Existing GitHub/OpenAI integration remains unchanged

## **TESTING RESULTS & ACCEPTANCE CRITERIA**
- `python -m py_compile changelog.py` ✅
- `python changelog.py --help` ✅
- Acceptance criteria met: dry-run preview and output override are available while default behavior remains intact.

## **BREAKING CHANGES**
None.

## **ROLLBACK PLAN**
Revert the three commits on this branch to restore the previous environment-variable-only behavior.

## **KNOWN LIMITATIONS / PENDING ITEMS**
- This PR does not add a dedicated test suite for the new CLI flags.

## **SCREENSHOTS / SCREEN RECORDINGS**
N/A - CLI/backend script change.

## **DOCUMENTATION & DEPLOYMENT NOTES**
No deployment changes required. Existing automation can continue calling `python changelog.py` without any new flags.
