### PR TITLE
Fix undefined pull variable in changelog aggregation

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -155,7 +155,7 @@ def fetch_pulls():
                     print(f"{assistant}: Writing pulls - " + pulls['title'])
 
                 category = categorize_items(pulls['title'])
-                all_repo_items[category].append(pr)
+                all_repo_items[category].append(pulls)
 
             # Move to the next page
             page += 1

--- a/tests/test_changelog_bugfix.py
+++ b/tests/test_changelog_bugfix.py
@@ -1,0 +1,111 @@
+# pyright: reportAttributeAccessIssue=false, reportArgumentType=false
+
+import os
+import runpy
+import sys
+import tempfile
+import types
+from pathlib import Path
+import unittest
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class RequestsStub:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        if len(self.calls) == 1:
+            return DummyResponse(
+                [
+                    {
+                        "title": "Add support for GitHub issue sync",
+                        "number": 42,
+                        "user": {"login": "alice"},
+                        "closed_at": "2026-06-05T12:00:00Z",
+                        "html_url": "https://github.com/BytesCrafter/python-devops/pull/42",
+                    }
+                ]
+            )
+        return DummyResponse([])
+
+
+class ChangelogPullAggregationTests(unittest.TestCase):
+    def test_pull_entries_are_written_when_the_loop_uses_the_current_payload(self):
+        requests_stub = RequestsStub()
+        openai_stub = types.ModuleType("openai")
+
+        class DummyOpenAI:
+            def __init__(self, api_key=None):
+                self.api_key = api_key
+
+        openai_stub.OpenAI = DummyOpenAI
+
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+        original_modules = {
+            name: sys.modules.get(name)
+            for name in ("requests", "openai", "dotenv")
+        }
+
+        try:
+            sys.modules["requests"] = requests_stub
+            sys.modules["openai"] = openai_stub
+            sys.modules["dotenv"] = dotenv_stub
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                env_updates = {
+                    "ASSISTANT_NAME": "TEST",
+                    "PROJECT_PATH": tmpdir,
+                    "RELEASE_NAME": "DevOps Automation Script by BytesCrafter",
+                    "RELEASE_VERSION": "1.0.0",
+                    "RELEASE_DATE": "June 5, 2026",
+                    "GITHUB_OWNER": "BytesCrafter",
+                    "GITHUB_REPO": "python-devops",
+                    "GITHUB_TOKEN": "dummy-token",
+                    "GITHUB_TARGET": "pulls",
+                    "CHANGELOG_SANITIZATION_PATTERN": "^$",
+                    "CHANGELOG_SPECIAL_NOTE": "None",
+                    "CHANGELOG_OPENAI_SUMMARIZE": "False",
+                    "CHANGELOG_ITEM_OPENAI_TITLE": "False",
+                    "CHANGELOG_NOTE_OPENAI_GENERATE": "False",
+                    "CHANGELOG_ITEM_WITH_TIME": "False",
+                }
+
+                previous_env = {key: os.environ.get(key) for key in env_updates}
+                os.environ.update(env_updates)
+                try:
+                    runpy.run_path("changelog.py", run_name="__main__")
+                finally:
+                    for key, value in previous_env.items():
+                        if value is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = value
+
+                changelog_path = Path(tmpdir) / "CHANGELOG.md"
+                self.assertTrue(changelog_path.exists(), "CHANGELOG.md should be generated")
+                changelog_content = changelog_path.read_text(encoding="utf-8")
+                self.assertIn("Add support for GitHub issue sync", changelog_content)
+                self.assertIn("### Added", changelog_content)
+                self.assertEqual(len(requests_stub.calls), 2)
+        finally:
+            for name, module in original_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fix undefined pull variable in changelog aggregation

## **SUMMARY**
Fix the pull-request aggregation loop so changelog generation stores the current pull payload instead of referencing an undefined variable.

## **LINKED ISSUES**
Closes #12

## **PR TYPE & SCOPE**
Bug fix, limited to `changelog.py` and one regression test under `tests/`.

## **FEATURES / CHANGES IMPLEMENTED**
- Replaced the incorrect `pr` append target with the active `pulls` payload.
- Added a regression test that runs the script with stubbed GitHub/OpenAI dependencies.
- Verified the generated changelog includes the expected pull title and category output.

## **FILES ADDED**
- `tests/test_changelog_bugfix.py`

## **FILES MODIFIED**
- `changelog.py`

## **TECH STACK DETAILS**
- Python 3.11
- Standard library `unittest`
- Existing `requests`, `python-dotenv`, and `openai` integration paths exercised via stubs

## **TESTING RESULTS & ACCEPTANCE CRITERIA**
- `python -m unittest discover -s tests -v` ✅
- The changelog script now writes `CHANGELOG.md` for a representative pull payload.
- The regression test confirms the aggregation loop uses the current pull object.

## **BREAKING CHANGES**
None.

## **ROLLBACK PLAN**
Revert commits `ae16ccb` and `88be3fd` if the regression test or changelog output needs to be restored to the previous state.

## **KNOWN LIMITATIONS / PENDING ITEMS**
- The script still relies on environment variables being present and well-formed.
- Additional API-path validation is tracked separately.

## **SCREENSHOTS / SCREEN RECORDINGS**
Not applicable.

## **DOCUMENTATION & DEPLOYMENT NOTES**
No deployment changes required. The changelog generator remains compatible with the existing workflow.
