### PR TITLE
Handle missing optional changelog flags without crashing

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -17,6 +17,14 @@ import requests
 import openai
 from openai import OpenAI
 
+
+def env_flag(name, default=False):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 assistant = os.getenv("ASSISTANT_NAME", "PEASANT")
 print(f"{assistant}: CHANGELOG generation is initializing...")
 
@@ -27,16 +35,16 @@ compare_base = os.getenv("GITHUB_COMPARED_BASE", "release")
 compare_head = os.getenv("GITHUB_COMPARED_HEAD", "develop")
 date_since = os.getenv("GITHUB_SCAN_DATE_SINCE", "2025-01-01")
 
-changelog_openai_summarize = os.getenv("CHANGELOG_OPENAI_SUMMARIZE", False).lower() == 'true'
+changelog_openai_summarize = env_flag("CHANGELOG_OPENAI_SUMMARIZE")
 openai_summarize_pretext = os.getenv("OPENAI_SUMMARIZE")
 
-changelog_openai_title = os.getenv("CHANGELOG_ITEM_OPENAI_TITLE", False).lower() == 'true'
-changelog_openai_special_note = os.getenv("CHANGELOG_NOTE_OPENAI_GENERATE", False).lower() == 'true'
+changelog_openai_title = env_flag("CHANGELOG_ITEM_OPENAI_TITLE")
+changelog_openai_special_note = env_flag("CHANGELOG_NOTE_OPENAI_GENERATE")
 changelog_openai_note_instructions = os.getenv("OPENAI_NOTE_INSTRUCTIONS")
 changelog_special_note = os.getenv("CHANGELOG_SPECIAL_NOTE")
-changelog_with_time = os.getenv("CHANGELOG_ITEM_WITH_TIME", False).lower() == 'true'
+changelog_with_time = env_flag("CHANGELOG_ITEM_WITH_TIME")
 
-sanitization_pattern = os.getenv("CHANGELOG_SANITIZATION_PATTERN")
+sanitization_pattern = os.getenv("CHANGELOG_SANITIZATION_PATTERN") or ""
 github_target = os.getenv("GITHUB_TARGET")
 
 # Replace with the version and release date.
@@ -65,7 +73,7 @@ all_repo_items = {
 }
 
 # GitHub API endpoint to get pull requests
-pull_request_url = f'https://api.github.com/repos/{owner}/{repo}/pulls?state=all&base=release&head=develop'
+pull_request_url = f'https://api.github.com/repos/{owner}/{repo}/pulls?state=all&base={compare_base}&head={compare_head}'
 issues_url = f'https://api.github.com/repos/{owner}/{repo}/issues?state=closed'
 commits_url = f'https://api.github.com/repos/{owner}/{repo}/compare/{compare_base}...{compare_head}'
 
@@ -138,7 +146,8 @@ def fetch_pulls():
 
             # Append the data to all_repo_items
             for pulls in pr_data:
-                pulls['title'] = re.sub(sanitization_pattern, '', pulls['title'])
+                if sanitization_pattern:
+                    pulls['title'] = re.sub(sanitization_pattern, '', pulls['title'])
                 if pulls['title'].startswith(':'):
                     pulls['title'] = pulls['title'][1:]
                 if pulls['title'].startswith('-'):
@@ -155,7 +164,7 @@ def fetch_pulls():
                     print(f"{assistant}: Writing pulls - " + pulls['title'])
 
                 category = categorize_items(pulls['title'])
-                all_repo_items[category].append(pr)
+                all_repo_items[category].append(pulls)
 
             # Move to the next page
             page += 1
@@ -185,7 +194,8 @@ def fetch_issues():
 
             # Append the data to all_repo_items
             for issue in issue_data:
-                issue['title'] = re.sub(sanitization_pattern, '', issue['title'])
+                if sanitization_pattern:
+                    issue['title'] = re.sub(sanitization_pattern, '', issue['title'])
                 if issue['title'].startswith(':'):
                     issue['title'] = issue['title'][1:]
                 if issue['title'].startswith('-'):
@@ -324,7 +334,7 @@ if any(all_repo_items.values()):
         changelog_content += special_note_generated
         print(f"{assistant}: SPECIAL NOTE GENERATED - " + special_note_generated)
     else:
-        changelog_content += "{changelog_special_note}"
+        changelog_content += changelog_special_note or ""
 
     if changelog_openai_summarize:
         changelog_content = send_chat(openai_summarize_pretext + changelog_content, os.getenv("OPENAI_INSTRUCTIONS"))

--- a/tests/test_changelog_compare_targets.py
+++ b/tests/test_changelog_compare_targets.py
@@ -1,0 +1,180 @@
+# pyright: reportAttributeAccessIssue=false, reportArgumentType=false
+
+import os
+import runpy
+import sys
+import tempfile
+import types
+from pathlib import Path
+import unittest
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class RequestsStub:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        if len(self.calls) == 1:
+            return DummyResponse(
+                [
+                    {
+                        "title": "Add compare target verification",
+                        "number": 99,
+                        "user": {"login": "bob"},
+                        "closed_at": "2026-06-05T12:00:00Z",
+                        "html_url": "https://github.com/BytesCrafter/python-devops/pull/99",
+                    }
+                ]
+            )
+        return DummyResponse([])
+
+
+class ChangelogCompareTargetTests(unittest.TestCase):
+    def test_pull_query_uses_configured_compare_branches(self):
+        requests_stub = RequestsStub()
+        openai_stub = types.ModuleType("openai")
+
+        class DummyOpenAI:
+            def __init__(self, api_key=None):
+                self.api_key = api_key
+
+        openai_stub.OpenAI = DummyOpenAI
+
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+        original_modules = {
+            name: sys.modules.get(name)
+            for name in ("requests", "openai", "dotenv")
+        }
+
+        try:
+            sys.modules["requests"] = requests_stub
+            sys.modules["openai"] = openai_stub
+            sys.modules["dotenv"] = dotenv_stub
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                env_updates = {
+                    "ASSISTANT_NAME": "TEST",
+                    "PROJECT_PATH": tmpdir,
+                    "RELEASE_NAME": "DevOps Automation Script by BytesCrafter",
+                    "RELEASE_VERSION": "1.0.0",
+                    "RELEASE_DATE": "June 5, 2026",
+                    "GITHUB_OWNER": "BytesCrafter",
+                    "GITHUB_REPO": "python-devops",
+                    "GITHUB_TOKEN": "dummy-token",
+                    "GITHUB_TARGET": "pulls",
+                    "GITHUB_COMPARED_BASE": "mainline",
+                    "GITHUB_COMPARED_HEAD": "release-candidate",
+                    "CHANGELOG_SANITIZATION_PATTERN": "^$",
+                    "CHANGELOG_SPECIAL_NOTE": "None",
+                    "CHANGELOG_OPENAI_SUMMARIZE": "False",
+                    "CHANGELOG_ITEM_OPENAI_TITLE": "False",
+                    "CHANGELOG_NOTE_OPENAI_GENERATE": "False",
+                    "CHANGELOG_ITEM_WITH_TIME": "False",
+                }
+
+                previous_env = {key: os.environ.get(key) for key in env_updates}
+                os.environ.update(env_updates)
+                try:
+                    runpy.run_path("changelog.py", run_name="__main__")
+                finally:
+                    for key, value in previous_env.items():
+                        if value is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = value
+
+                changelog_path = Path(tmpdir) / "CHANGELOG.md"
+                self.assertTrue(changelog_path.exists(), "CHANGELOG.md should be generated")
+                changelog_content = changelog_path.read_text(encoding="utf-8")
+                self.assertIn("Add compare target verification", changelog_content)
+                self.assertEqual(len(requests_stub.calls), 2)
+                self.assertIn("base=mainline", requests_stub.calls[0])
+                self.assertIn("head=release-candidate", requests_stub.calls[0])
+                self.assertNotIn("base=release", requests_stub.calls[0])
+                self.assertNotIn("head=develop", requests_stub.calls[0])
+        finally:
+            for name, module in original_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+    def test_missing_optional_boolean_flags_do_not_crash(self):
+        requests_stub = RequestsStub()
+        openai_stub = types.ModuleType("openai")
+
+        class DummyOpenAI:
+            def __init__(self, api_key=None):
+                self.api_key = api_key
+
+        openai_stub.OpenAI = DummyOpenAI
+
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+        original_modules = {
+            name: sys.modules.get(name)
+            for name in ("requests", "openai", "dotenv")
+        }
+
+        try:
+            sys.modules["requests"] = requests_stub
+            sys.modules["openai"] = openai_stub
+            sys.modules["dotenv"] = dotenv_stub
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                env_updates = {
+                    "ASSISTANT_NAME": "TEST",
+                    "PROJECT_PATH": tmpdir,
+                    "RELEASE_NAME": "DevOps Automation Script by BytesCrafter",
+                    "RELEASE_VERSION": "1.0.0",
+                    "RELEASE_DATE": "June 5, 2026",
+                    "GITHUB_OWNER": "BytesCrafter",
+                    "GITHUB_REPO": "python-devops",
+                    "GITHUB_TOKEN": "dummy-token",
+                    "GITHUB_TARGET": "pulls",
+                    "GITHUB_COMPARED_BASE": "mainline",
+                    "GITHUB_COMPARED_HEAD": "release-candidate",
+                    "CHANGELOG_SANITIZATION_PATTERN": "^$",
+                }
+
+                previous_env = {key: os.environ.get(key) for key in env_updates}
+                os.environ.update(env_updates)
+                try:
+                    runpy.run_path("changelog.py", run_name="__main__")
+                finally:
+                    for key, value in previous_env.items():
+                        if value is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = value
+
+                changelog_path = Path(tmpdir) / "CHANGELOG.md"
+                self.assertTrue(changelog_path.exists(), "CHANGELOG.md should be generated")
+                changelog_content = changelog_path.read_text(encoding="utf-8")
+                self.assertIn("Add compare target verification", changelog_content)
+                self.assertEqual(len(requests_stub.calls), 2)
+                self.assertIn("base=mainline", requests_stub.calls[0])
+                self.assertIn("head=release-candidate", requests_stub.calls[0])
+        finally:
+            for name, module in original_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Handle missing optional changelog flags without crashing
## **SUMMARY**
This change hardens the changelog generator so missing optional boolean environment variables no longer crash the script during import. It also fixes the pull request compare URL to honor the configured compare branches and corrects the fallback special-note append behavior.

## **LINKED ISSUES**
Closes #16

## **PR TYPE & SCOPE**
Bug fix / quality hardening for the changelog generation workflow.

## **FEATURES / CHANGES IMPLEMENTED**
- Added a small `env_flag()` helper to normalize optional boolean environment variables safely.
- Switched all optional changelog feature flags to the new helper.
- Guarded sanitization regex usage so an empty pattern does not trigger unnecessary substitutions.
- Fixed the pull request compare URL to use the configured compare base/head values.
- Corrected the non-OpenAI special-note fallback so it appends the configured value instead of a literal template string.
- Added regression coverage for the configured compare branches and the no-optional-flags path.

## **FILES ADDED**
- `tests/test_changelog_compare_targets.py`

## **FILES MODIFIED**
- `changelog.py`

## **TECH STACK DETAILS**
- Python 3.8+
- `requests`
- `python-dotenv`
- `openai`
- `unittest`

## **TESTING RESULTS & ACCEPTANCE CRITERIA**
- `python -m unittest discover -s tests` ✅
- Missing optional boolean environment variables no longer crash the script.
- Configured compare branches are used when building the pull request query.
- Generated changelog output remains intact for the existing compare-target flow.

## **BREAKING CHANGES**
None.

## **ROLLBACK PLAN**
Revert commits `41948fd` and `5b03739` if the hardened environment parsing causes an unexpected regression.

## **KNOWN LIMITATIONS / PENDING ITEMS**
- The script still expects the standard GitHub/OpenAI environment variables to be provided by the runtime.
- Empty-result changelog scaffolding is tracked separately.

## **SCREENSHOTS / SCREEN RECORDINGS**
Not applicable.

## **DOCUMENTATION & DEPLOYMENT NOTES**
No documentation changes were required for this bug fix. The change is safe to deploy with the existing CI workflow.
