### PR TITLE
Emit an empty changelog scaffold when no items match the release window

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -281,61 +281,64 @@ print(f"{assistant}: Completed processing items from server.")
 
 # Calculate the path two directories back
 log_path = os.path.join(project_path, "CHANGELOG.md")
+has_items = any(all_repo_items.values())
 
-# Proceed with writing the changelog if pull requests were fetched
-if any(all_repo_items.values()):
-    changelog_content = f"# {project_name}\n\n"
-    changelog_content += "All notable changes to this project will be documented in this file.\n\n"
-    changelog_content += "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n"
-    changelog_content += f"### {release_version} - {release_date} Release \n\n"
+# Always write a scaffold, even when no matching items are found.
+changelog_content = f"# {project_name}\n\n"
+changelog_content += "All notable changes to this project will be documented in this file.\n\n"
+changelog_content += "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n"
+changelog_content += f"### {release_version} - {release_date} Release \n\n"
 
+if has_items:
     print(f"{assistant}: Categorizing the CHANGELOG items to Added, Changed, Fixed, and Removed.")
-
-    # Group PRs into categories and add to the changelog
-    for category in ["Added", "Changed", "Fixed", "Removed", "Other"]:
-        changelog_content += f"### {category} \n\n"
-        for repo_item in all_repo_items[category]:
-            item_title = repo_item['title']
-            item_number = repo_item['number']
-            item_user = repo_item['user']['login']
-            item_date = repo_item['closed_at']
-            item_url = repo_item['html_url']
-            user_url = f"https://github.com/{item_user}"
-    
-            # Convert the closed_at date to datetime and format it
-            closed_date = datetime.strptime(item_date, "%Y-%m-%dT%H:%M:%SZ")
-
-            if changelog_with_time:
-                formatted_date = closed_date.strftime("%Y-%m-%d %I:%M %p")
-            else:
-                formatted_date = closed_date.strftime("%Y-%m-%d")
-
-            pre_text = f" [#{item_number}]({item_url}) - "
-
-            # Adding the item number as a markdown link and formatted date
-            changelog_content += f"-{pre_text} {item_title} by [{item_user}]({user_url}) (Closed on {formatted_date})\n"
-
-    print(f"{assistant}: Finalizing the CHANGELOG footer for special notes and contributors.")
-
-    # Add the footer of the file.
-    changelog_content += "## Special Notes\n\n"
-    if changelog_openai_special_note:
-        special_note_generated = send_chat(changelog_openai_note_instructions + changelog_content, os.getenv("OPENAI_INSTRUCTIONS"))
-        changelog_content += special_note_generated
-        print(f"{assistant}: SPECIAL NOTE GENERATED - " + special_note_generated)
-    else:
-        changelog_content += "{changelog_special_note}"
-
-    if changelog_openai_summarize:
-        changelog_content = send_chat(openai_summarize_pretext + changelog_content, os.getenv("OPENAI_INSTRUCTIONS"))
-    
-    changelog_content += "\n\n"
-    changelog_content += "Special thanks to the development team, [@BytesCrafter](https://github.com/BytesCrafter), [@caezariidecastro](https://github.com/caezariidecastro), [@BC-Tristan](https://github.com/BC-Tristan), [@BC-Patrick](https://github.com/BC-Patrick)! 💯🥳\n"
-
-    # Write to CHANGELOG file with UTF-8 encoding
-    with open(log_path, "w", encoding="utf-8") as file:
-        file.write(changelog_content)
-    
-    print(f"{assistant}: Changelog written to {log_path}")
 else:
-    print(f"{assistant}: No {github_target} found or failed to fetch them.")
+    print(f"{assistant}: No matching changelog items were found; writing an empty-state scaffold.")
+
+# Group PRs into categories and add to the changelog
+for category in ["Added", "Changed", "Fixed", "Removed", "Other"]:
+    changelog_content += f"### {category} \n\n"
+    if not has_items and category == "Other":
+        changelog_content += "- No qualifying issues or pull requests were found for this release window.\n"
+    for repo_item in all_repo_items[category]:
+        item_title = repo_item['title']
+        item_number = repo_item['number']
+        item_user = repo_item['user']['login']
+        item_date = repo_item['closed_at']
+        item_url = repo_item['html_url']
+        user_url = f"https://github.com/{item_user}"
+
+        # Convert the closed_at date to datetime and format it
+        closed_date = datetime.strptime(item_date, "%Y-%m-%dT%H:%M:%SZ")
+
+        if changelog_with_time:
+            formatted_date = closed_date.strftime("%Y-%m-%d %I:%M %p")
+        else:
+            formatted_date = closed_date.strftime("%Y-%m-%d")
+
+        pre_text = f" [#{item_number}]({item_url}) - "
+
+        # Adding the item number as a markdown link and formatted date
+        changelog_content += f"-{pre_text} {item_title} by [{item_user}]({user_url}) (Closed on {formatted_date})\n"
+
+print(f"{assistant}: Finalizing the CHANGELOG footer for special notes and contributors.")
+
+# Add the footer of the file.
+changelog_content += "## Special Notes\n\n"
+if changelog_openai_special_note:
+    special_note_generated = str(send_chat((changelog_openai_note_instructions or "") + changelog_content, os.getenv("OPENAI_INSTRUCTIONS") or ""))
+    changelog_content += special_note_generated
+    print(f"{assistant}: SPECIAL NOTE GENERATED - " + special_note_generated)
+else:
+    changelog_content += str(changelog_special_note or "")
+
+if changelog_openai_summarize:
+    changelog_content = str(send_chat((openai_summarize_pretext or "") + changelog_content, os.getenv("OPENAI_INSTRUCTIONS") or ""))
+
+changelog_content += "\n\n"
+changelog_content += "Special thanks to the development team, [@BytesCrafter](https://github.com/BytesCrafter), [@caezariidecastro](https://github.com/caezariidecastro), [@BC-Tristan](https://github.com/BC-Tristan), [@BC-Patrick](https://github.com/BC-Patrick)! 💯🥳\n"
+
+# Write to CHANGELOG file with UTF-8 encoding
+with open(log_path, "w", encoding="utf-8") as file:
+    file.write(changelog_content)
+
+print(f"{assistant}: Changelog written to {log_path}")

--- a/tests/test_changelog_empty_state.py
+++ b/tests/test_changelog_empty_state.py
@@ -1,0 +1,99 @@
+# pyright: reportAttributeAccessIssue=false, reportArgumentType=false
+
+import os
+import runpy
+import sys
+import tempfile
+import types
+from pathlib import Path
+import unittest
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class EmptyRequestsStub:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        return DummyResponse([])
+
+
+class ChangelogEmptyStateTests(unittest.TestCase):
+    def test_empty_state_still_writes_scaffold(self):
+        requests_stub = EmptyRequestsStub()
+        openai_stub = types.ModuleType("openai")
+
+        class DummyOpenAI:
+            def __init__(self, api_key=None):
+                self.api_key = api_key
+
+        openai_stub.OpenAI = DummyOpenAI
+
+        dotenv_stub = types.ModuleType("dotenv")
+        dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+        original_modules = {
+            name: sys.modules.get(name)
+            for name in ("requests", "openai", "dotenv")
+        }
+
+        try:
+            sys.modules["requests"] = requests_stub
+            sys.modules["openai"] = openai_stub
+            sys.modules["dotenv"] = dotenv_stub
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                env_updates = {
+                    "ASSISTANT_NAME": "TEST",
+                    "PROJECT_PATH": tmpdir,
+                    "RELEASE_NAME": "DevOps Automation Script by BytesCrafter",
+                    "RELEASE_VERSION": "1.0.0",
+                    "RELEASE_DATE": "June 5, 2026",
+                    "GITHUB_OWNER": "BytesCrafter",
+                    "GITHUB_REPO": "python-devops",
+                    "GITHUB_TOKEN": "dummy-token",
+                    "GITHUB_TARGET": "pulls",
+                    "CHANGELOG_SANITIZATION_PATTERN": "^$",
+                    "CHANGELOG_OPENAI_SUMMARIZE": "False",
+                    "CHANGELOG_ITEM_OPENAI_TITLE": "False",
+                    "CHANGELOG_NOTE_OPENAI_GENERATE": "False",
+                    "CHANGELOG_ITEM_WITH_TIME": "False",
+                    "CHANGELOG_SPECIAL_NOTE": "",
+                }
+
+                previous_env = {key: os.environ.get(key) for key in env_updates}
+                os.environ.update(env_updates)
+                try:
+                    runpy.run_path("changelog.py", run_name="__main__")
+                finally:
+                    for key, value in previous_env.items():
+                        if value is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = value
+
+                changelog_path = Path(tmpdir) / "CHANGELOG.md"
+                self.assertTrue(changelog_path.exists(), "CHANGELOG.md should be generated")
+                changelog_content = changelog_path.read_text(encoding="utf-8")
+                self.assertIn("No qualifying issues or pull requests were found for this release window.", changelog_content)
+                self.assertIn("### Other", changelog_content)
+                self.assertEqual(len(requests_stub.calls), 1)
+        finally:
+            for name, module in original_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Emit an empty changelog scaffold when no items match the release window
## **SUMMARY**
This change ensures the changelog generator still writes a valid `CHANGELOG.md` scaffold even when no qualifying pull requests or issues are found for the selected release window. The empty-state output gives CI and release automation a deterministic artifact to consume.

## **LINKED ISSUES**
Closes #17

## **PR TYPE & SCOPE**
Feature / reporting hardening for the changelog generation workflow.

## **FEATURES / CHANGES IMPLEMENTED**
- Always initialize the changelog output before evaluating whether any items were found.
- Add a clear empty-state note when no qualifying issues or pull requests are returned.
- Preserve the standard release header, category headings, and special notes section in empty runs.
- Add regression coverage for the empty-state path.

## **FILES ADDED**
- `tests/test_changelog_empty_state.py`

## **FILES MODIFIED**
- `changelog.py`

## **TECH STACK DETAILS**
- Python 3.8+
- `requests`
- `python-dotenv`
- `openai`
- `unittest`

## **TESTING RESULTS & ACCEPTANCE CRITERIA**
- `python -m unittest discover -s tests` ✅
- `CHANGELOG.md` is written even when the compare result set is empty.
- The generated file includes a clear empty-state note.
- Standard changelog structure remains intact for downstream automation.

## **BREAKING CHANGES**
None.

## **ROLLBACK PLAN**
Revert commits `f3c3414` and `a7ac1c0` if the empty-state scaffold causes an unexpected release workflow regression.

## **KNOWN LIMITATIONS / PENDING ITEMS**
- The release-note content is intentionally minimal for empty runs.
- Additional wording polish can be handled in a future documentation pass.

## **SCREENSHOTS / SCREEN RECORDINGS**
Not applicable.

## **DOCUMENTATION & DEPLOYMENT NOTES**
No documentation changes were required. This is a safe workflow hardening update for changelog generation.
